### PR TITLE
Add `rem` as unit to the default spacing configuration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,11 +55,11 @@ module.exports = {
     spacing: {
       auto: 'auto',
       0: '0',
-      1: '1',
-      2: '2',
-      4: '4',
-      8: '8',
-      16: '16',
+      1: '1rem',
+      2: '2rem',
+      4: '4rem',
+      8: '8rem',
+      16: '16rem',
     },
     margin: (theme, { negative }) => ({
       auto: 'auto',

--- a/src/index.js
+++ b/src/index.js
@@ -55,11 +55,11 @@ module.exports = {
     spacing: {
       auto: 'auto',
       0: '0',
-      1: '1rem',
-      2: '2rem',
-      4: '4rem',
-      8: '8rem',
-      16: '16rem',
+      1: '0.5rem',
+      2: '1rem',
+      4: '2rem',
+      8: '4rem',
+      16: '8rem',
     },
     margin: (theme, { negative }) => ({
       auto: 'auto',


### PR DESCRIPTION
This PR fixes the missing units in the spacing and sizing utility classes.