### PR TITLE
Fix the [data-breakpoint] pseudo element display

### DIFF
--- a/src/plugins/breakpoint.js
+++ b/src/plugins/breakpoint.js
@@ -6,11 +6,7 @@ module.exports = plugin(
 
     addComponents({
       '[data-breakpoint]::after, [data-breakpoint]::before': {
-        zIndex: -999,
-        position: 'absolute',
         display: 'none',
-        opacity: 0,
-        pointerEvents: 'none',
       },
       '[data-breakpoint]::after': {
         content: `'${Object.keys(screens).join(',')}'`,

--- a/src/plugins/breakpoint.js
+++ b/src/plugins/breakpoint.js
@@ -8,6 +8,7 @@ module.exports = plugin(
       '[data-breakpoint]::after, [data-breakpoint]::before': {
         zIndex: -999,
         position: 'absolute',
+        display: 'none',
         opacity: 0,
         pointerEvents: 'none',
       },


### PR DESCRIPTION
## Bug description
The pseudo elements `[data-breakpoint]:before` and `[data-breakpoint]:after`does not have a display value, this is layout breaking. This is adding a transparent pseudo element at the top and bottom of the <body>. 

See exemple sceenshot. 
![Capture d’écran 2020-09-09 à 09 18 53](https://user-images.githubusercontent.com/11503190/92567137-871ed500-f27d-11ea-9e6c-3b60aa71cf9b.png)

## Fix 
Add a `display: none` to hide those pseudo elements



